### PR TITLE
fix logout, by adding sid

### DIFF
--- a/library/Synology/Api.php
+++ b/library/Synology/Api.php
@@ -77,7 +77,7 @@ class Synology_Api extends Synology_Abstract{
 	 */
 	public function disconnect(){
 		$this->log($this->_sessionName, 'Disconnect Session');
-		$this->_request('Auth', 'auth.cgi', 'logout', array('session' => $this->_sessionName));
+		$this->_request('Auth', 'auth.cgi', 'logout', array('_sid' => $this->_sid,'session' => $this->_sessionName));
 		$this->_sid = null;
 		return $this;
 	}


### PR DESCRIPTION
Logout was not working, because without the sid the synology does not know which session to delete.
Without working logout sessions will accumulate until the API is no longer responsive.

Can be verified seen by looking at /usr/syno/etc/private/session/current.users file on the synology.

Personally I think this is an upstream (synology) error for returning 200 on logout requests without sid.
