### PR TITLE
[TASK] Added stream endpoint

### DIFF
--- a/library/Synology/AudioStation/Api.php
+++ b/library/Synology/AudioStation/Api.php
@@ -33,7 +33,7 @@ class Synology_AudioStation_Api extends Synology_Api_Authenticate{
 	 * @param int $offset
 	 * @return array
 	 */
-	public function getObjects($type, $limit = 25, $offset = 0){
+	public function getObjects($type, $limit = 25, $offset = 0, $additional = 'song_tag,song_audio,song_rating'){
 		$path = '';
 		switch ($type){
 			case 'Album':
@@ -59,7 +59,7 @@ class Synology_AudioStation_Api extends Synology_Api_Authenticate{
 			default:
 				throw new Synology_Exception('Unknow "'.$type.'" object');
 		}
-		return $this->_request($type, $path, 'list', array('limit' => $limit, 'offset' => $offset));
+		return $this->_request($type, $path, 'list', array('limit' => $limit, 'offset' => $offset, 'additional' => $additional));
 	}
 	
 	/**
@@ -140,7 +140,7 @@ class Synology_AudioStation_Api extends Synology_Api_Authenticate{
 				'limit' => $limit,
 				'sort_by' => $sortby,
 				'sort_direction' => $sortdirection
-		));
+		), 2, 'post');
 	}
 	
 	/**
@@ -162,6 +162,13 @@ class Synology_AudioStation_Api extends Synology_Api_Authenticate{
 				'sort_by' => $sortby,
 				'sort_direction' => $sortdirection,
 				'additional' => $additional
-		));
+		), 2, 'post');
+	}
+	
+	public function stream($id) {
+		return $this->_request('Stream', 'AudioStation/stream.cgi', 'stream', array(
+			'id' => $id
+		), 2, 'get');
+		
 	}
 }


### PR DESCRIPTION
-Updated the getObjects call to include additional info; like song tags and tech. details
-Added the stream endpoint

My PHP knowledge isn't great enough to tackle one thing with streaming though
Using this endpoint lets a user get the audio content by calling $synology->stream('music_xxx');
This is returned as byte-range if the browser supports it (if the API call is done directly from a browser ofc). Best is to relay ALL response headers from the API but I don't know how to do that and more importantly *where* it should go; in the AudioStation API wrapper or the demo code.
Any help with this issue is really appreciated!

I will continue to port more AudioStation API calls to the PHP wrapper so we can provide a fully working API for AudioStation alternatives.