### PR TITLE
FileStation API upgrades + added createFolder API method

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This is a PHP Library that consume Synology APIs
     * getList
     * search
     * download
+    * createFolder
     
 * SYNO.VideoStation:
     * connect

--- a/src/Synology/Api.php
+++ b/src/Synology/Api.php
@@ -61,6 +61,7 @@ class Synology_Api extends Synology_Abstract
         $data = $this->_request('Auth', 'auth.cgi', 'login', $options, 3);
         
         // save session name id
+        $data = json_decode($data);
         $this->_sid = $data->data->sid;
         
         return $this;

--- a/src/Synology/Api.php
+++ b/src/Synology/Api.php
@@ -61,7 +61,7 @@ class Synology_Api extends Synology_Abstract
         $data = $this->_request('Auth', 'auth.cgi', 'login', $options, 3);
         
         // save session name id
-        $this->_sid = $data->sid;
+        $this->_sid = $data->data->sid;
         
         return $this;
     }

--- a/src/Synology/Api.php
+++ b/src/Synology/Api.php
@@ -58,7 +58,7 @@ class Synology_Api extends Synology_Abstract
             'session' => $this->_sessionName,
             'format' => 'sid'
         );
-        $data = $this->_request('Auth', 'auth.cgi', 'login', $options, 2);
+        $data = $this->_request('Auth', 'auth.cgi', 'login', $options, 3);
         
         // save session name id
         $this->_sid = $data->sid;

--- a/src/Synology/FileStation/Api.php
+++ b/src/Synology/FileStation/Api.php
@@ -45,14 +45,14 @@ class Synology_FileStation_Api extends Synology_Api_Authenticate
      */
     public function getShares($onlywritable = false, $limit = 25, $offset = 0, $sortby = 'name', $sortdirection = 'asc', $additional = false)
     {
-        return $this->_request('List', 'FileStation/file_share.cgi', 'list_share', array(
+        return $this->_request('List', 'entry.cgi', 'list_share', array(
             'onlywritable' => $onlywritable,
             'limit' => $limit,
             'offset' => $offset,
             'sort_by' => $sortby,
             'sort_direction' => $sortdirection,
             'additional' => $additional ? 'real_path,owner,time,perm,volume_status' : ''
-        ));
+        ), 2);
     }
 
     /**
@@ -122,7 +122,7 @@ class Synology_FileStation_Api extends Synology_Api_Authenticate
      */
     public function search($pattern, $path = '/home', $limit = 25, $offset = 0, $sortby = 'name', $sortdirection = 'asc', $filetype = 'all', $additional = false)
     {
-        return $this->_request('List', 'FileStation/file_share.cgi', 'list', array(
+        return $this->_request('List', 'entry.cgi', 'list', array(
             'folder_path' => $path,
             'limit' => $limit,
             'offset' => $offset,
@@ -131,7 +131,7 @@ class Synology_FileStation_Api extends Synology_Api_Authenticate
             'pattern' => $pattern,
             'filetype' => $filetype,
             'additional' => $additional ? 'real_path,size,owner,time,perm' : ''
-        ));
+        ), 2);
     }
 
     /**
@@ -143,10 +143,10 @@ class Synology_FileStation_Api extends Synology_Api_Authenticate
      */
     public function download($path, $mode = 'open')
     {
-        return $this->_request('Download', 'FileStation/file_download.cgi', 'download', array(
+        return $this->_request('Download', 'entry.cgi', 'download', array(
             'path' => $path,
             'mode' => $mode
-        ));
+        ), 2);
     }
 
     /**

--- a/src/Synology/FileStation/Api.php
+++ b/src/Synology/FileStation/Api.php
@@ -148,4 +148,22 @@ class Synology_FileStation_Api extends Synology_Api_Authenticate
             'mode' => $mode
         ));
     }
+
+    /**
+     * Create a folder
+     * 
+     * @param $path
+     * @param $name
+     * @param false $force_parent
+     * @return bool|stdClass
+     * @throws Synology_Exception
+     */
+    public function createFolder($path, $name, $force_parent = false)
+    {
+        return $this->_request('CreateFolder', 'entry.cgi', 'create', array(
+            'folder_path' => $path,
+            'name' => $name,
+            'force_parent' => true,
+        ), 2);
+    }
 }

--- a/src/Synology/FileStation/Api.php
+++ b/src/Synology/FileStation/Api.php
@@ -22,14 +22,14 @@ class Synology_FileStation_Api extends Synology_Api_Authenticate
     }
 
     /**
-     * Return Information about VideoStation
+     * Return Information about FileStation
      * - is_manager
      * - version
      * - version_string
      */
     public function getInfo()
     {
-        return $this->_request('Info', 'FileStation/info.cgi', 'getinfo');
+        return $this->_request('Info', 'entry.cgi', 'get', [], 2);
     }
 
     /**

--- a/src/Synology/FileStation/Api.php
+++ b/src/Synology/FileStation/Api.php
@@ -95,7 +95,7 @@ class Synology_FileStation_Api extends Synology_Api_Authenticate
      */
     public function getList($path = '/home', $limit = 25, $offset = 0, $sortby = 'name', $sortdirection = 'asc', $pattern = '', $filetype = 'all', $additional = false)
     {
-        return $this->_request('List', 'FileStation/file_share.cgi', 'list', array(
+        return $this->_request('List', 'entry.cgi', 'list_share', array(
             'folder_path' => $path,
             'limit' => $limit,
             'offset' => $offset,
@@ -104,7 +104,7 @@ class Synology_FileStation_Api extends Synology_Api_Authenticate
             'pattern' => $pattern,
             'filetype' => $filetype,
             'additional' => $additional ? 'real_path,size,owner,time,perm' : ''
-        ));
+        ), 2);
     }
 
     /**


### PR DESCRIPTION
Version 2 of the Auth API is no longer supported, I get the following error: 
```
{"error":{"code":103},"success":false}
```

When changing to 3 (up to 7), it works again.


I've also upgraded the other Synology FileStation API's to version 2 since version 1 was no longer working.
I've also added the createFolder API method.

Feel free to add more methods. Documentation can be found at https://global.download.synology.com/download/Document/Software/DeveloperGuide/Package/FileStation/All/enu/Synology_File_Station_API_Guide.pdf.